### PR TITLE
Bump crypto shortener pkg and remove ts ignore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@rainbow-me/rainbowkit": "2.0.1",
         "@tanstack/react-query": "5.59.9",
         "ace-builds": "1.36.2",
-        "crypto-shortener": "1.0.0",
+        "crypto-shortener": "1.1.0",
         "hemi-viem": "1.5.0",
         "react": "18.2.0",
         "react-ace": "12.0.0",
@@ -8741,9 +8741,9 @@
       }
     },
     "node_modules/crypto-shortener": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-shortener/-/crypto-shortener-1.0.0.tgz",
-      "integrity": "sha512-zh+mGvEP0QbvpDQ7Iu1ymWaQ939qzB/2V6f/H8NL1lBI0uPVkr5pYt0qeb104wd2mmzngcm30DY5UyZd2q+qiQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/crypto-shortener/-/crypto-shortener-1.1.0.tgz",
+      "integrity": "sha512-Ital05DIQzuwULtp+GHuz1RHbFpdcJqVjoKjxfXw3TTZdjagYZuZ9VKXnKZ0zi4mmoCEYDwxnPt8YD+YJiYBHA==",
       "engines": {
         "node": ">=16.11"
       }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@rainbow-me/rainbowkit": "2.0.1",
     "@tanstack/react-query": "5.59.9",
     "ace-builds": "1.36.2",
-    "crypto-shortener": "1.0.0",
+    "crypto-shortener": "1.1.0",
     "hemi-viem": "1.5.0",
     "react": "18.2.0",
     "react-ace": "12.0.0",

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,6 +1,3 @@
-// Ignored because the crypto-shortener package is not typed yet
-// It shold be fixed soon
-//@ts-ignore
 import { shorten } from 'crypto-shortener'
 import { hemiTestnet } from 'networks/hemiTestnet'
 


### PR DESCRIPTION
This PR bumps Crypto shortener pkg and remove the `ts-ignore` since this new version has typescript support.

Closes #24 