### PR TITLE
Security improvements - Replace wallet for publicClient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "bitcoin-kit-demo",
       "version": "1.0.0",
       "dependencies": {
-        "@rainbow-me/rainbowkit": "2.0.1",
         "@tanstack/react-query": "5.59.9",
         "ace-builds": "1.36.2",
         "crypto-shortener": "1.1.0",
@@ -1838,11 +1837,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@emotion/hash": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
-      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g=="
-    },
     "node_modules/@es-joy/jsdoccomment": {
       "version": "0.36.1",
       "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
@@ -3663,37 +3657,6 @@
       "optional": true,
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@rainbow-me/rainbowkit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@rainbow-me/rainbowkit/-/rainbowkit-2.0.1.tgz",
-      "integrity": "sha512-htE5nI0/2Q4UcLuiVW4IDmA6bqSyEzIB/XNcD1MEvYyLLZRTdQ8YGUhXAlZfYCC2Q+TcfYAxS826XcfPXwh7nQ==",
-      "dependencies": {
-        "@vanilla-extract/css": "1.14.0",
-        "@vanilla-extract/dynamic": "2.1.0",
-        "@vanilla-extract/sprinkles": "1.6.1",
-        "clsx": "2.1.0",
-        "qrcode": "1.5.3",
-        "react-remove-scroll": "2.5.7",
-        "ua-parser-js": "^1.0.37"
-      },
-      "engines": {
-        "node": ">=12.4"
-      },
-      "peerDependencies": {
-        "react": ">=17",
-        "react-dom": ">=17",
-        "viem": "2.x",
-        "wagmi": "2.x"
-      }
-    },
-    "node_modules/@rainbow-me/rainbowkit/node_modules/clsx": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
-      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@react-native-community/cli": {
@@ -6693,109 +6656,6 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
-    "node_modules/@vanilla-extract/css": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@vanilla-extract/css/-/css-1.14.0.tgz",
-      "integrity": "sha512-rYfm7JciWZ8PFzBM/HDiE2GLnKI3xJ6/vdmVJ5BSgcCZ5CxRlM9Cjqclni9lGzF3eMOijnUhCd/KV8TOzyzbMA==",
-      "dependencies": {
-        "@emotion/hash": "^0.9.0",
-        "@vanilla-extract/private": "^1.0.3",
-        "chalk": "^4.1.1",
-        "css-what": "^6.1.0",
-        "cssesc": "^3.0.0",
-        "csstype": "^3.0.7",
-        "deep-object-diff": "^1.1.9",
-        "deepmerge": "^4.2.2",
-        "media-query-parser": "^2.0.2",
-        "modern-ahocorasick": "^1.0.0",
-        "outdent": "^0.8.0"
-      }
-    },
-    "node_modules/@vanilla-extract/css/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@vanilla-extract/css/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@vanilla-extract/css/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@vanilla-extract/css/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/@vanilla-extract/css/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@vanilla-extract/css/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@vanilla-extract/dynamic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@vanilla-extract/dynamic/-/dynamic-2.1.0.tgz",
-      "integrity": "sha512-8zl0IgBYRtgD1h+56Zu13wHTiMTJSVEa4F7RWX9vTB/5Xe2KtjoiqApy/szHPVFA56c+ex6A4GpCQjT1bKXbYw==",
-      "dependencies": {
-        "@vanilla-extract/private": "^1.0.3"
-      }
-    },
-    "node_modules/@vanilla-extract/private": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@vanilla-extract/private/-/private-1.0.6.tgz",
-      "integrity": "sha512-ytsG/JLweEjw7DBuZ/0JCN4WAQgM9erfSTdS1NQY778hFQSZ6cfCDEZZ0sgVm4k54uNz6ImKB33AYvSR//fjxw=="
-    },
-    "node_modules/@vanilla-extract/sprinkles": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vanilla-extract/sprinkles/-/sprinkles-1.6.1.tgz",
-      "integrity": "sha512-N/RGKwGAAidBupZ436RpuweRQHEFGU+mvAqBo8PRMAjJEmHoPDttV8RObaMLrJHWLqvX+XUMinHUnD0hFRQISw==",
-      "peerDependencies": {
-        "@vanilla-extract/css": "^1.0.0"
-      }
-    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.3.0.tgz",
@@ -8748,21 +8608,11 @@
         "node": ">=16.11"
       }
     },
-    "node_modules/css-what": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
       "bin": {
         "cssesc": "bin/cssesc"
       },
@@ -8773,7 +8623,8 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "devOptional": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -8891,15 +8742,11 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
-    "node_modules/deep-object-diff": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.9.tgz",
-      "integrity": "sha512-Rn+RuwkmkDwCi2/oXOFS9Gsr5lJZu/yTGpK7wAaAIE75CC+LCGEZHpY6VQJa/RoJcrmaA/docWJZvYohlNkWPA=="
-    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9016,11 +8863,6 @@
       "engines": {
         "node": ">=0.10"
       }
-    },
-    "node_modules/detect-node-es": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
-      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -11039,14 +10881,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-nonce": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
-      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/get-port-please": {
@@ -13516,14 +13350,6 @@
       "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
       "dev": true
     },
-    "node_modules/media-query-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/media-query-parser/-/media-query-parser-2.0.2.tgz",
-      "integrity": "sha512-1N4qp+jE0pL5Xv4uEcwVUhIkwdUO3S/9gML90nqKA7v7FcOS5vUtatfzok9S9U1EJU8dHWlcv95WLnKmmxZI9w==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      }
-    },
     "node_modules/memoize-one": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
@@ -14309,11 +14135,6 @@
         "ufo": "^1.5.4"
       }
     },
-    "node_modules/modern-ahocorasick": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/modern-ahocorasick/-/modern-ahocorasick-1.0.1.tgz",
-      "integrity": "sha512-yoe+JbhTClckZ67b2itRtistFKf8yPYelHLc7e5xAwtNAXxM6wJTUx2C7QeVSJFDzKT7bCIFyBVybPMKvmB9AA=="
-    },
     "node_modules/motion": {
       "version": "10.16.2",
       "resolved": "https://registry.npmjs.org/motion/-/motion-10.16.2.tgz",
@@ -15090,11 +14911,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/outdent": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.8.0.tgz",
-      "integrity": "sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A=="
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -16406,51 +16222,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-remove-scroll": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.7.tgz",
-      "integrity": "sha512-FnrTWO4L7/Bhhf3CYBNArEG/yROV0tKmTv7/3h9QCFvH6sndeFf1wPqOcbFVu5VAulS5dV1wGT3GZZ/1GawqiA==",
-      "dependencies": {
-        "react-remove-scroll-bar": "^2.3.4",
-        "react-style-singleton": "^2.2.1",
-        "tslib": "^2.1.0",
-        "use-callback-ref": "^1.3.0",
-        "use-sidecar": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-remove-scroll-bar": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.6.tgz",
-      "integrity": "sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==",
-      "dependencies": {
-        "react-style-singleton": "^2.2.1",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-router": {
       "version": "6.23.1",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.1.tgz",
@@ -16479,28 +16250,6 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/react-style-singleton": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
-      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
-      "dependencies": {
-        "get-nonce": "^1.0.0",
-        "invariant": "^2.2.4",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/read-cache": {
@@ -18455,31 +18204,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/ua-parser-js": {
-      "version": "1.0.39",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.39.tgz",
-      "integrity": "sha512-k24RCVWlEcjkdOxYmVJgeD/0a1TiSpqLg+ZalVGV9lsnr4yqu0w7tX/x2xX6G4zpkgQnRf89lxuZ1wsbjXM8lw==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        }
-      ],
-      "bin": {
-        "ua-parser-js": "script/cli.js"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -18737,47 +18461,6 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/use-callback-ref": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.2.tgz",
-      "integrity": "sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-sidecar": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
-      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
-      "dependencies": {
-        "detect-node-es": "^1.1.0",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "tsc": "tsc --noEmit"
   },
   "dependencies": {
-    "@rainbow-me/rainbowkit": "2.0.1",
     "@tanstack/react-query": "5.59.9",
     "ace-builds": "1.36.2",
     "crypto-shortener": "1.1.0",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,11 +1,9 @@
 import { RouterProvider } from 'react-router-dom'
 
 import './styles/index.css'
-import '@rainbow-me/rainbowkit/styles.css'
 import { router } from './router'
 import { WagmiProvider } from 'wagmi'
 import { WalletContext } from 'context/walletContext'
-import { RainbowKitProvider, lightTheme } from '@rainbow-me/rainbowkit'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 export const App = () => {
@@ -14,14 +12,7 @@ export const App = () => {
     <div className="bg-neutral-50">
       <WagmiProvider config={WalletContext}>
         <QueryClientProvider client={queryClient}>
-          <RainbowKitProvider
-            locale="en-US"
-            theme={lightTheme({
-              accentColor: 'black',
-            })}
-          >
-            <RouterProvider router={router} />
-          </RainbowKitProvider>
+          <RouterProvider router={router} />
         </QueryClientProvider>
       </WagmiProvider>
     </div>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,6 +1,4 @@
-import { ConnectButton } from '@rainbow-me/rainbowkit'
 import { WarningIcon } from 'icons/warning'
-import { useAccount } from 'wagmi'
 
 const HemiLogo = () => (
   <svg viewBox="0 0 1043.5 324.5" xmlns="http://www.w3.org/2000/svg">
@@ -17,14 +15,12 @@ const HemiLogo = () => (
 )
 
 const NetworkLabel = () => {
-  const { chain } = useAccount()
-
   return (
     <p className="solid flex items-center justify-center text-base font-medium leading-normal text-orange-950">
       <span className="rounded-full border border-orange-200/55 bg-orange-50 px-3 py-1">
         Hemi Bitcoin Kit Demo
       </span>
-      {chain?.testnet && <span className="ml-2">Testnet</span>}
+      <span className="ml-2">Testnet</span>
     </p>
   )
 }
@@ -43,9 +39,6 @@ export const Header = function () {
         <span className="ml-1 text-base font-medium text-rose-600">
           Do not sign any transactions or approvals within this app
         </span>
-      </div>
-      <div className="hidden sm:flex">
-        <ConnectButton />
       </div>
     </header>
   )

--- a/src/context/walletContext.tsx
+++ b/src/context/walletContext.tsx
@@ -1,25 +1,8 @@
-import { connectorsForWallets } from '@rainbow-me/rainbowkit'
-import { metaMaskWallet } from '@rainbow-me/rainbowkit/wallets'
 import { hemiTestnet } from 'networks/hemiTestnet'
 import { createConfig, http } from 'wagmi'
 
-const connectors = connectorsForWallets(
-  [
-    {
-      groupName: 'Wallets',
-      wallets: [metaMaskWallet],
-    },
-  ],
-  {
-    // These values are required but not actually used, unless wallet connect is enabled
-    appName: 'My RainbowKit App',
-    projectId: 'YOUR_PROJECT_ID',
-  },
-)
-
 export const WalletContext = createConfig({
   chains: [hemiTestnet],
-  connectors,
   transports: {
     [hemiTestnet.id]: http(),
   },

--- a/src/pages/codeEditor/_components/codeEditor.tsx
+++ b/src/pages/codeEditor/_components/codeEditor.tsx
@@ -21,7 +21,6 @@ interface Props {
   onHandleExecute: () => void
   onToggleTheme: () => void
   selectedMethod: DefaultCode
-  walletConnected?: boolean | Chain
 }
 
 export const CodeEditor = ({
@@ -32,7 +31,6 @@ export const CodeEditor = ({
   onChange,
   onToggleTheme,
   selectedMethod,
-  walletConnected,
 }: Props) => {
   return (
     <>
@@ -56,11 +54,11 @@ export const CodeEditor = ({
             onClick={onHandleExecute}
             className={`w-28 rounded-xl border py-1.5 text-base font-normal text-white transition-all duration-300
             ${
-              loading || !walletConnected
+              loading
                 ? 'cursor-default border-neutral-300 bg-execute-button-disabled'
                 : 'cursor-pointer bg-execute-button hover:brightness-90'
             }`}
-            disabled={loading || !walletConnected}
+            disabled={loading}
           >
             {loading ? 'Executing...' : 'Execute'}
           </button>

--- a/src/pages/codeEditor/defaultCode/btcBalAddr.ts
+++ b/src/pages/codeEditor/defaultCode/btcBalAddr.ts
@@ -17,7 +17,7 @@ const bitcoinAddress = "<REPLACE_WITH_BITCOIN_ADDRESS>";
 // Get the contract instance with the contract address and ABI using wagmi/viem.
 // The contract address is also provided through the state.
 const contract = getContract({
-  client: walletClient,
+  client: publicClient,
   address: contractAddress,
   abi: ABI,
 });

--- a/src/pages/codeEditor/defaultCode/btcHeaderN.ts
+++ b/src/pages/codeEditor/defaultCode/btcHeaderN.ts
@@ -17,7 +17,7 @@ const headerIndex = "<REPLACE_WITH_HEADER_INDEX>";
 // Get the contract instance with the contract address and ABI using wagmi/viem.
 // The contract address is also provided through the state.
 const contract = getContract({
-  client: walletClient,
+  client: publicClient,
   address: contractAddress,
   abi: ABI,
 });

--- a/src/pages/codeEditor/defaultCode/btcLastHeader.ts
+++ b/src/pages/codeEditor/defaultCode/btcLastHeader.ts
@@ -13,7 +13,7 @@ const code = `
 // Get the contract instance with the contract address and ABI using wagmi/viem.
 // The contract address is also provided through the state.
 const contract = getContract({
-  client: walletClient,
+  client: publicClient,
   address: contractAddress,
   abi: ABI,
 });

--- a/src/pages/codeEditor/defaultCode/btcTxByTxid.ts
+++ b/src/pages/codeEditor/defaultCode/btcTxByTxid.ts
@@ -21,7 +21,7 @@ const txid = "0x<REPLACE_WITH_TXID>";
 // Get the contract instance with the contract address and ABI using wagmi/viem.
 // The contract address is also provided through the state.
 const contract = getContract({
-  client: walletClient,
+  client: publicClient,
   address: contractAddress,
   abi: ABI,
 });

--- a/src/pages/codeEditor/defaultCode/btcTxConfirmations.ts
+++ b/src/pages/codeEditor/defaultCode/btcTxConfirmations.ts
@@ -17,7 +17,7 @@ const txid = "0x<REPLACE_WITH_TXID>";
 // Get the contract instance with the contract address and ABI using wagmi/viem.
 // The contract address is also provided through the state.
 const contract = getContract({
-  client: walletClient,
+  client: publicClient,
   address: contractAddress,
   abi: ABI,
 });

--- a/src/pages/codeEditor/defaultCode/btcUtxosAddrList.ts
+++ b/src/pages/codeEditor/defaultCode/btcUtxosAddrList.ts
@@ -24,7 +24,7 @@ const maxUtxos = 10; // Limit to 10 UTXOs per call
 // Get the contract instance with the contract address and ABI using wagmi/viem.
 // The contract address is also provided through the state.
 const contract = getContract({
-  client: walletClient,
+  client: publicClient,
   address: contractAddress,
   abi: ABI,
 });

--- a/src/pages/codeEditor/page.tsx
+++ b/src/pages/codeEditor/page.tsx
@@ -4,7 +4,7 @@ import ABI from '../../contracts/ContractABI'
 import defaultCode from './defaultCode/main'
 import { Output } from './_components/output'
 import { getContract } from 'viem'
-import { useAccount, useWalletClient } from 'wagmi'
+import { usePublicClient } from 'wagmi'
 import { Tab, TabPage } from 'components/tabPage'
 import { DefaultCode, DefaultCodeName } from 'types/defaultCode'
 import btcBalAddr from './defaultCode/btcBalAddr'
@@ -14,8 +14,7 @@ import { CodeEditor, ThemeEditorEnum } from './_components/codeEditor'
 const contractAddress = import.meta.env.VITE_HEMI_BITCOIN_KIT_CONTRACT_ADDRESS
 
 export const CodeEditorPage = () => {
-  const { data: walletClient } = useWalletClient()
-  const { status, chain } = useAccount()
+  const publicClient = usePublicClient()
   const [selectedMethod, setSelectedMethod] = useState<DefaultCode>(btcBalAddr)
   const [ThemeEditor, setThemeEditor] = useState<ThemeEditorEnum>(
     ThemeEditorEnum.default,
@@ -27,8 +26,6 @@ export const CodeEditorPage = () => {
   const [error, setError] = useState<string | null>(null)
   const [logs, setLogs] = useState<string[]>([])
   const [loading, setLoading] = useState(false)
-
-  const walletConnected = status === 'connected' && chain
 
   const handleMethodChange = (tab: Tab) => {
     const method = defaultCode.find(c => c.name === tab.name)
@@ -67,7 +64,7 @@ export const CodeEditorPage = () => {
       const asyncFunc = new Function(
         'contractAddress',
         'getContract',
-        'walletClient',
+        'publicClient',
         'ABI',
         `
         return (async () => {
@@ -79,7 +76,7 @@ export const CodeEditorPage = () => {
       const result = await asyncFunc(
         contractAddress,
         getContract,
-        walletClient,
+        publicClient,
         ABI,
       )
       setOutput(result ? safeJsonStringify(result) : 'No output')
@@ -124,7 +121,6 @@ export const CodeEditorPage = () => {
               onChange={setCode}
               onToggleTheme={toggleTheme}
               selectedMethod={selectedMethod}
-              walletConnected={walletConnected}
             />
           </div>
           <div className="h-full w-auto pb-10 pt-2 lg:ml-6 lg:w-1/4">


### PR DESCRIPTION
This PR replaces the full walletClient support for the viem public client. Thanks to that, the app does not allow sign transactions, improving general security. This is possible because all precompiles, at least currently, they are static calls. In addition to that, `rainbowkit` component, including the connect to the wallet button was removed. 

Next step should be **mainnet** support through a toggle button. 

cc/ @rmilrad @dvnahuel 

![Captura de Tela 2024-11-19 às 10 23 16](https://github.com/user-attachments/assets/ef20c729-57c0-4e78-ac93-2682c22e9c87)

Closes #25 