### PR TITLE
Override testnet RPC to devnet

### DIFF
--- a/src/networks/hemiTestnet.ts
+++ b/src/networks/hemiTestnet.ts
@@ -1,4 +1,7 @@
 import { hemiSepolia } from 'hemi-viem'
 import { overrideRpcUrl } from './utils'
 
-export const hemiTestnet = overrideRpcUrl(hemiSepolia)
+export const hemiTestnet = overrideRpcUrl(
+  hemiSepolia,
+  'https://devnet2.rpc.hemi.network/rpc',
+)


### PR DESCRIPTION
We are having some trouble to test on testnet so @max-sanchez mentioned to use the devnet RPC. This PR overrides the RPC to devnet. cc/ @rmilrad 