### PR TITLE
Fix production deployment workflow build args

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -32,7 +32,7 @@ jobs:
         ghcr.io/hemilabs/bitcoin-kit:${{ github.sha }}
       build-args: |
         BUILD_MODE=mainnet
-        VITE_HEMI_BITCOIN_KIT_ANALYTICS_WEBSITE_ID=${{ secrets.VITE_HEMI_BITCOIN_KIT_ANALYTICS_WEBSITE_ID }}
+        VITE_HEMI_BITCOIN_KIT_ANALYTICS_WEBSITE_ID=${{ vars.VITE_HEMI_BITCOIN_KIT_ANALYTICS_WEBSITE_ID }}
     secrets:
       DOCKERHUB_USERNAME: "${{ secrets.DOCKERHUB_USERNAME }}"
       DOCKERHUB_PASSWORD: "${{ secrets.DOCKERHUB_TOKEN }}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitcoin-kit-demo",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bitcoin-kit-demo",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "@tanstack/react-query": "5.59.9",
         "ace-builds": "1.36.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoin-kit-demo",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Bitcoin Kit Demo",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes the production deployment workflow to properly pass the analytics website ID as a build argument.

**Note:** Before creating a release tag, the `VITE_HEMI_BITCOIN_KIT_ANALYTICS_WEBSITE_ID` variable needs to be added in repository Settings.