### PR TITLE
Enable Umami page view tracking

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -27,7 +27,7 @@ export const App = () => {
     <div className="bg-neutral-50">
       <NuqsAdapter>
         <UmamiAnalyticsProvider
-          autoTrack={false}
+          autoTrack
           {...(websiteId && {
             src: 'https://umami.hemi.xyz/t.js',
             websiteId,


### PR DESCRIPTION
This PR fixes Umami page view tracking, which was silently disabled — the demo was reporting **0 page views** even though custom events were being recorded normally.