### PR TITLE
Fix JS Checks workflow reference

### DIFF
--- a/.github/workflows/js-checks.yml
+++ b/.github/workflows/js-checks.yml
@@ -8,8 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   js-checks:
-    uses: hemilabs/actions/.github/workflows/js-checks.yml@main
-    with:
-      node-versions: '["16", "18", "20", "22"]'
+    uses: hemilabs/.github/.github/workflows/js-checks.yml@c0d930f1959633dd7dc1203d95ec6634dbaf9a34 # v1.2.0


### PR DESCRIPTION
This PR fixes the JS Checks workflow, which was failing at startup on every push and PR.

The reusable workflow it called — `hemilabs/actions/.github/workflows/js-checks.yml@main` — no longer exists; those reusable workflows moved to `hemilabs/.github`. So the run 404'd before doing anything (a 0s failure). This points it at the npm `js-checks.yml` in `hemilabs/.github`, pinned to `v1.2.0` — the same ref `ui-monorepo` uses.