### PR TITLE
Fix production deploy workflow reference

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -18,7 +18,7 @@ jobs:
   # Build and push Docker image
   docker:
     name: Docker
-    uses: hemilabs/actions/.github/workflows/docker.yml@main
+    uses: hemilabs/.github/.github/workflows/docker.yml@c0d930f1959633dd7dc1203d95ec6634dbaf9a34 # v1.2.0
     permissions:
       contents: read
       packages: write # Needed to push to the GitHub Container Registry


### PR DESCRIPTION
This PR fixes the production deploy workflow, which points at a reusable workflow that no longer exists.

`deploy-production.yml` called `hemilabs/actions/.github/workflows/docker.yml@main`, but those reusable workflows moved to `hemilabs/.github` — so the path 404s and the deploy would fail on the next release. This repoints it to the `docker.yml` in `hemilabs/.github`, pinned to `v1.2.0` (same ref as the JS Checks fix). The inputs and secrets the caller passes (`version`, `context`, `file`, `tags`, `build-args`, `dockerhub`, and the DockerHub secrets) all match the new workflow's interface unchanged.