### PR TITLE
Bump to v1.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitcoin-kit-demo",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bitcoin-kit-demo",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "dependencies": {
         "@tanstack/react-query": "5.59.9",
         "ace-builds": "1.36.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoin-kit-demo",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Bitcoin Kit Demo",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR bumps the app version to v1.2.3 ahead of cutting the release tag.